### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## *DICT - API*
 
-Bem vindo à especificação da API do DICT, o Diretório de Identificadores de Contas 
+Bem-vindo à especificação da API do DICT, o Diretório de Identificadores de Contas 
 Transacionais do PIX (Sistema de Pagamentos Instantâneos do Banco Central do Brasil). 
 O público-alvo são profissionais de TI dos Prestadores de Serviços de Pagamentos (PSP). 
 


### PR DESCRIPTION
Correção de um erro de digitação/ortografia.
Faltava um hífen no _bem-vindo_ do README.

Bem vindo _->_ bem-vindo



Ref.: https://querobolsa.com.br/revista/bem-vindo-ou-bem-vindo-como-se-escreve